### PR TITLE
feat: 내가 가입한 클럽들 조회 기능 추가

### DIFF
--- a/src/controllers/clubControllers.js
+++ b/src/controllers/clubControllers.js
@@ -14,7 +14,9 @@ export const joinClub = async (req, res) => {
       .json({ message: "동아리에 성공적으로 가입했습니다." });
   } catch (error) {
     logger.error(`동아리 가입 실패: ${error.message}`, { error });
-    return res.status(500).json({ message: "서버 오류가 발생했습니다." });
+    return res
+      .status(500)
+      .json({ message: `동아리 가입 실패: ${error.message}` });
   }
 };
 
@@ -29,7 +31,9 @@ export const quitClub = async (req, res) => {
     return res.status(200).json({ message: "동아리 탈퇴를 성공했습니다." });
   } catch (error) {
     logger.error(`동아리 탈퇴 실패: ${error.message}`, { error });
-    return res.status(500).json({ message: "서버 오류가 발생했습니다." });
+    return res
+      .status(500)
+      .json({ message: `동아리 탈퇴 실패: ${error.message}` });
   }
 };
 
@@ -44,7 +48,9 @@ export const kickMember = async (req, res) => {
     return res.status(200).json({ message: "회원 강퇴를 성공했습니다." });
   } catch (error) {
     logger.error(`동아리 추방 실패: ${error.message}`, { error });
-    return res.status(500).json({ message: "서버 오류가 발생했습니다." });
+    return res
+      .status(500)
+      .json({ message: `동아리 추방 실패: ${error.message}` });
   }
 };
 
@@ -59,7 +65,9 @@ export const changeCode = async (req, res) => {
     logger.error(`동아리 가입 코드 변경 중 오류 발생 ${error.message}`, {
       error,
     });
-    return res.status(500).json({ message: "서버 오류가 발생했습니다." });
+    return res
+      .status(500)
+      .json({ message: `동아리 가입 코드 변경 중 오류 발생 ${error.message}` });
   }
 };
 
@@ -74,7 +82,9 @@ export const changeLeader = async (req, res) => {
     return res.status(200).json({ message: "동아리 회장이 변경 되었습니다." });
   } catch (error) {
     logger.error(`동아리 회장 변경 중 오류 발생: ${error.message}`, { error });
-    return res.status(500).json({ message: "서버 오류가 발생했습니다." });
+    return res
+      .status(500)
+      .json({ message: `동아리 회장 변경 중 오류 발생: ${error.message}` });
   }
 };
 
@@ -94,6 +104,19 @@ export const viewClub = async (req, res) => {
     logger.error(`동아리 목록 조회 검증 실패: ${error.message}`, { error });
     return res
       .status(500)
-      .json({ message: "동아리 조회 중 오류가 발생했습니다." });
+      .json({ message: `동아리 목록 조회 검증 실패: ${error.message}` });
+  }
+};
+
+export const getMyClubs = async (req, res) => {
+  try {
+    const userId = req.user.user_id;
+    const clubs = await ClubService.getMyClubs(userId);
+    return res.status(200).json(clubs);
+  } catch (error) {
+    logger.error(`내 동아리 조회 중 오류 발생: ${error.message}`, { error });
+    return res
+      .status(500)
+      .json({ message: `내 동아리 조회 중 오류 발생: ${error.message}` });
   }
 };

--- a/src/repositories/clubRepository.js
+++ b/src/repositories/clubRepository.js
@@ -80,4 +80,21 @@ export const clubRepository = {
       },
     });
   },
+
+  getMyClubs: async (userId) => {
+    return await prisma.clubMember.findMany({
+      where: { user_id: userId },
+      select: {
+        club: {
+          select: {
+            club_id: true,
+            club_name: true,
+            club_code: true,
+            member_count: true,
+            created_at: true,
+          },
+        },
+      },
+    });
+  },
 };

--- a/src/routes/clubRoutes.js
+++ b/src/routes/clubRoutes.js
@@ -12,7 +12,9 @@ import {
   kickMember,
   changeCode,
   changeLeader,
+  getMyClubs,
 } from "../controllers/clubControllers.js";
+import { get } from "http";
 
 const router = express.Router();
 
@@ -35,5 +37,7 @@ router.post(
 router.patch("/:clubId/setting", verifyClub, isLeader, changeCode); //동아리 가입 코드 변경
 
 router.patch("/:clubId/leader", verifyClub, isLeader, changeLeader); //동아리 회장 변경
+
+router.get("/getclubs/:userId", getMyClubs); //내 동아리 조회
 
 export default router;

--- a/src/services/clubService.js
+++ b/src/services/clubService.js
@@ -1,3 +1,4 @@
+import { getMyClubs } from "../controllers/clubControllers.js";
 import { clubRepository } from "../repositories/clubRepository.js";
 import { logger } from "../utils/logger.js";
 
@@ -66,5 +67,11 @@ export const ClubService = {
 
     logger.debug("clubinfo, members객체 생성 성공");
     return { clubInfo, members };
+  },
+
+  getMyClubs: async (userId) => {
+    const myClubs = await clubRepository.getMyClubs(userId);
+    logger.debug("내 동아리 목록 조회 성공");
+    return myClubs;
   },
 };


### PR DESCRIPTION
<img width="313" alt="image" src="https://github.com/user-attachments/assets/cc39e859-cd8c-4c60-b444-efda19f98548" />
라우터에서 controllers의 getMyClubs 호출

<img width="380" alt="image" src="https://github.com/user-attachments/assets/f053165e-764f-4242-b5ce-b6c06a5186e5" />
컨트롤러에서 Services의 getMyClubs 호출

<img width="305" alt="image" src="https://github.com/user-attachments/assets/c4d4faf3-487a-4d5a-a1c1-576e0d25d820" />
Services에서 Repository의 getMyClubs 호출

<img width="270" alt="image" src="https://github.com/user-attachments/assets/58d78a81-0dd9-4103-9c16-34306dd43ebb" />
Repository에서 DB 조회 후 데이터 반환


추가 변경 사항 : http 에러 메세지를 전달할때, error.message를 전달하여, 프론트에서 피드백 전달하기 쉽게 변경하였습니다.


